### PR TITLE
update scullc to Linux4.10(except procfs-entry)

### DIFF
--- a/misc-modules/jit.c
+++ b/misc-modules/jit.c
@@ -30,6 +30,7 @@
 #include <linux/spinlock.h>
 #include <linux/interrupt.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <linux/slab.h>
 
 #include <asm/hardirq.h>

--- a/scullc/Makefile
+++ b/scullc/Makefile
@@ -4,12 +4,12 @@
 
 
 ifeq ($(DEBUG),y)
-  DEBFLAGS = -O -g -DSCULLC_DEBUG # "-O" is needed to expand inlines
+  DEBFLAGS = -O -g -DSCULLC_DEBUG -DSCULLC_USE_PROC# "-O" is needed to expand inlines
 else
   DEBFLAGS = -O2
 endif
 
-CFLAGS += $(DEBFLAGS) -I$(LDDINC)
+ccflags-y += $(DEBFLAGS) -I$(LDDINC)
 
 TARGET = scullc
 

--- a/scullc/scullc_init
+++ b/scullc/scullc_init
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Sample init script for the a driver module <rubini@linux.it>
+
+DEVICE="scullc"
+SECTION="misc"
+
+# The list of filenames and minor numbers: $PREFIX is prefixed to all names
+PREFIX="scullc"
+FILES="     0 0         1 1         2 2        3 3"
+
+INSMOD=/sbin/insmod; # use /sbin/modprobe if you prefer
+
+function device_specific_post_load () {
+    true; # fill at will
+}
+function device_specific_pre_unload () {
+    true; # fill at will
+}
+
+# Everything below this line should work unchanged for any char device.
+# Obviously, however, no options on the command line: either in
+# /etc/${DEVICE}.conf or /etc/modules.conf (if modprobe is used)
+
+# Optional configuration file: format is
+#    owner  <ownername>
+#    group  <groupname>
+#    mode   <modename>
+#    options <insmod options>
+CFG=/etc/${DEVICE}.conf
+
+# kernel version, used to look for modules
+KERNEL=`uname -r`
+
+#FIXME: it looks like there is no misc section. Where should it be?
+MODDIR="/lib/modules/${KERNEL}/kernel/drivers/${SECTION}"
+if [ ! -d $MODDIR ]; then MODDIR="/lib/modules/${KERNEL}/${SECTION}"; fi
+
+# Root or die
+if [ "$(id -u)" != "0" ]
+then
+  echo "You must be root to load or unload kernel modules"
+  exit 1
+fi
+
+# Read configuration file
+if [ -r $CFG ]; then
+    OWNER=`awk "\\$1==\"owner\" {print \\$2}" $CFG`
+    GROUP=`awk "\\$1==\"group\" {print \\$2}" $CFG`
+    MODE=`awk "\\$1==\"mode\" {print \\$2}" $CFG`
+    # The options string may include extra blanks or only blanks
+    OPTIONS=`sed -n '/^options / s/options //p' $CFG`
+fi
+
+
+# Create device files
+function create_files () {
+    cd /dev
+    local devlist=""
+    local file
+    while true; do
+	if [ $# -lt 2 ]; then break; fi
+	file="${DEVICE}$1"
+	mknod $file c $MAJOR $2
+	devlist="$devlist $file"
+	shift 2
+    done
+    if [ -n "$OWNER" ]; then chown $OWNER $devlist; fi
+    if [ -n "$GROUP" ]; then chgrp $GROUP $devlist; fi
+    if [ -n "$MODE"  ]; then chmod $MODE  $devlist; fi
+}
+
+# Remove device files
+function remove_files () {
+    cd /dev
+    local devlist=""
+    local file
+    while true; do
+	if [ $# -lt 2 ]; then break; fi
+	file="${DEVICE}$1"
+	devlist="$devlist $file"
+	shift 2
+    done
+    rm -f $devlist
+}
+
+# Load and create files
+function load_device () {
+    
+    if [ -f $MODDIR/$DEVICE.ko ]; then
+	devpath=$MODDIR/$DEVICE.ko
+    else if [ -f ./$DEVICE.ko ]; then
+	devpath=./$DEVICE.ko
+    else
+	devpath=$DEVICE; # let insmod/modprobe guess
+    fi; fi
+    if [ "$devpath" != "$DEVICE" ]; then
+	echo -n " (loading file $devpath)"
+    fi
+
+    if $INSMOD $devpath $OPTIONS; then
+	MAJOR=`awk "\\$2==\"$DEVICE\" {print \\$1}" /proc/devices`
+	remove_files $FILES
+	create_files $FILES
+	device_specific_post_load
+    else
+	echo " FAILED!"
+     fi
+}
+
+# Unload and remove files
+function unload_device () {
+    device_specific_pre_unload 
+    /sbin/rmmod $DEVICE
+    remove_files $FILES
+}
+
+
+case "$1" in
+  start)
+     echo -n "Loading $DEVICE"
+     load_device
+     echo "."
+     ;;
+  stop)
+     echo -n "Unloading $DEVICE"
+     unload_device
+     echo "."
+     ;;
+  force-reload|restart)
+     echo -n "Reloading $DEVICE"
+     unload_device
+     load_device
+     echo "."
+     ;;
+  *)
+     echo "Usage: $0 {start|stop|restart|force-reload}"
+     exit 1
+esac
+
+exit 0


### PR DESCRIPTION
・非同期I/O実装方法を最新対応
   (Linux4.10では、file_operationsにはaio_read,aio_writeはなく、VFS経由で呼ばれるコアのaio_read,aio_writeがデバイスのread_iter,write_iterを使うので、それを用意)
・proc fsのエントリー登録はまだ未対応(seq_opを使う予定)