### PR TITLE
update lddbus to Linux4.10

### DIFF
--- a/lddbus/Makefile
+++ b/lddbus/Makefile
@@ -7,7 +7,7 @@ ifeq ($(DEBUG),y)
 else
   DEBFLAGS = -O2
 endif
-CFLAGS  += $(DEBFLAGS) -I$(LDDINCDIR)
+ccflags-y  += $(DEBFLAGS) -I$(LDDINCDIR)
 
 
 ifneq ($(KERNELRELEASE),)

--- a/lddbus/lddbus.c
+++ b/lddbus/lddbus.c
@@ -28,17 +28,14 @@ MODULE_LICENSE("Dual BSD/GPL");
 static char *Version = "$Revision: 1.9 $";
 
 /*
- * Respond to hotplug events.
+ * Respond to uevents
  */
-static int ldd_hotplug(struct device *dev, char **envp, int num_envp,
-		char *buffer, int buffer_size)
+static int ldd_uevent(struct device *dev, struct kobj_uevent_env *env)
 {
-	envp[0] = buffer;
-	if (snprintf(buffer, buffer_size, "LDDBUS_VERSION=%s",
-			    Version) >= buffer_size)
-		return -ENOMEM;
-	envp[1] = NULL;
-	return 0;
+    if(add_uevent_var(env, "LDDBUS_VERSION=%s", Version))
+        return -ENOMEM;
+
+    return 0;
 }
 
 /*
@@ -46,7 +43,7 @@ static int ldd_hotplug(struct device *dev, char **envp, int num_envp,
  */
 static int ldd_match(struct device *dev, struct device_driver *driver)
 {
-	return !strncmp(dev->bus_id, driver->name, strlen(driver->name));
+	return !strncmp(dev->bus->name, driver->name, strlen(driver->name));
 }
 
 
@@ -59,7 +56,6 @@ static void ldd_bus_release(struct device *dev)
 }
 	
 struct device ldd_bus = {
-	.bus_id   = "ldd0",
 	.release  = ldd_bus_release
 };
 
@@ -70,7 +66,7 @@ struct device ldd_bus = {
 struct bus_type ldd_bus_type = {
 	.name = "ldd",
 	.match = ldd_match,
-	.hotplug  = ldd_hotplug,
+	.uevent  = ldd_uevent,
 };
 
 /*
@@ -102,7 +98,6 @@ int register_ldd_device(struct ldd_device *ldddev)
 	ldddev->dev.bus = &ldd_bus_type;
 	ldddev->dev.parent = &ldd_bus;
 	ldddev->dev.release = ldd_dev_release;
-	strncpy(ldddev->dev.bus_id, ldddev->name, BUS_ID_SIZE);
 	return device_register(&ldddev->dev);
 }
 EXPORT_SYMBOL(register_ldd_device);
@@ -136,7 +131,6 @@ int register_ldd_driver(struct ldd_driver *driver)
 	if (ret)
 		return ret;
 	driver->version_attr.attr.name = "version";
-	driver->version_attr.attr.owner = driver->module;
 	driver->version_attr.attr.mode = S_IRUGO;
 	driver->version_attr.show = show_version;
 	driver->version_attr.store = NULL;

--- a/simple/simple.c
+++ b/simple/simple.c
@@ -98,9 +98,9 @@ static int Simple_remap_mmap(struct file *filp, struct vm_area_struct *vma)
 /*
  * The fault version.
  */
-static int Simple_vma_fault(struct vm_area_struct *vma,
-        struct vm_fault *vmf)
+static int Simple_vma_fault(struct vm_fault *vmf)
 {
+    struct vm_area_struct *vma = vmf->vma;
     struct page *pageptr;
     unsigned long offset = vma->vm_pgoff << PAGE_SHIFT;
     unsigned long address = (unsigned long) vmf->address;


### PR DESCRIPTION
・Linux4.10では、デバイスの脱着をhotplugではなく、uevent/udevで管理しているのでそれに対応